### PR TITLE
chore: normalize repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/kmalakoff/ts-swc-rollup-plugin",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/kmalakoff/ts-swc-rollup-plugin.git"
+    "url": "git+https://github.com/kmalakoff/ts-swc-rollup-plugin.git"
   },
   "license": "MIT",
   "author": "Kevin Malakoff <kmalakoff@gmail.com> (https://github.com/kmalakoff)",


### PR DESCRIPTION
## Summary

- normalize the npm `repository.url` from the SSH-style GitHub URL to the equivalent `git+https` URL
- leave runtime code, dependencies, package version, exports, homepage, and bugs metadata unchanged

## Validation

- Node package metadata assertion for the updated repository URL
- Compared current npm metadata for `ts-swc-rollup-plugin@2.4.0`, which still publishes `git+ssh://git@github.com/kmalakoff/ts-swc-rollup-plugin.git`

This is a manifest-only metadata change.